### PR TITLE
Fix link for noting feature

### DIFF
--- a/intro.md
+++ b/intro.md
@@ -83,7 +83,7 @@ feature:
 
 > Note: "the body" means the sack of meat and bone that you are currently living inside. For the purposes of explanation of this technique, please consider what makes you yourself separate from the body you live in.
 
-You are not your thoughts. Your thoughts are something [you can witness](https://github.com/Xe/when-then-zen/blob/master/meditation/noting.feature#L41).
+You are not your thoughts. Your thoughts are something [you can witness](https://github.com/Xe/when-then-zen/blob/master/bonus/noting.feature).
 You are not required to give your thoughts any attention they don't need. Try
 not immediately associating yourself with a few "negative" thoughts when they 
 come up next. Try digging through the chains of meaning to understand why they


### PR DESCRIPTION
I didn't preserve the line number because line 41 doesn't seem particularly special: https://github.com/Xe/when-then-zen/blob/edf27aa03e9eb57f6b63f6624baba48370c44035/bonus/noting.feature#L41

Closes #11