### PR TITLE
links audit - many dead, non-clickable, absolute

### DIFF
--- a/bonus/anapana.feature
+++ b/bonus/anapana.feature
@@ -12,7 +12,7 @@ Feature: Anapana meditation
 
   The method presented in this feature is based on the method taught in The Art
   Of Living by William Hart and S.N. Goenka. If you want a copy of this book you
-  can get one here: http://www.cicp.org.kh/userfiles/file/Publications/Art%20of%20Living%20in%20English.pdf
+  can get one here: [The Art of Living: Vipassana Meditation: As Taught by S. N. Goenka](https://web.archive.org/web/20160910121731/http://www.cicp.org.kh/userfiles/file/Publications/Art%20of%20Living%20in%20English.pdf)
   Please do keep in mind that this book definitely skews towards the Buddhist 
   lens and as it is presented the teaching methods really benefit from it.
 

--- a/bonus/metta.feature
+++ b/bonus/metta.feature
@@ -19,7 +19,7 @@ Feature: Loving-kindness (metta) meditation
   if that person is yourself. Generally as you are starting out it is best to
   choose people you consider loveable as targets for metta.
 
-  The method in this feature is based on metta as described in http://www.buddhanet.net/pdf_file/allmetta.pdf
+  The method in this feature is based on metta as described in [Loving-kindness Meditation by Ven. Sujiva](http://www.buddhanet.net/pdf_file/allmetta.pdf)
   This book HEAVILY slants into the Buddhist lens. If you read it, please be 
   prepared to scrape out the wisdom from its casing.
 

--- a/bonus/noting.feature
+++ b/bonus/noting.feature
@@ -18,7 +18,7 @@ Feature: Noting
   Definitely start with basic sensory noting before jumping into the free
   noting. You'll know when it's time.
   
-  If you want to read more, look here: https://www.insightmeditationcenter.org/books-articles/articles/mental-noting/
+  If you want to read more, look here: [Mental Noting by Gil Fronsdal](https://www.insightmeditationcenter.org/books-articles/articles/mental-noting/)
   
   Background:
     Given no assumption about meditative background

--- a/bonus/paracosm-immersion.feature
+++ b/bonus/paracosm-immersion.feature
@@ -18,17 +18,18 @@ Feature: Paracosm Immersion
   visualize and experience things better. 
   
   It's really not hard unless you make it hard. Make it easy and it will be 
-  trivial. I have been noting my progress here: https://write.as/ma-insa/
+  trivial. I have been noting my progress here: [ma-insa — Write.as](https://write.as/ma-insa/)
   
-  If you want to read more on the topic, look here: https://en.wikipedia.org/wiki/Paracosm
-  This subreddit may also be useful: https://www.reddit.com/r/paracosms/
+  If you want to read more on the topic, look here: [Paracosm - Wikipedia](https://en.wikipedia.org/wiki/Paracosm)
+  This subreddit may also be useful: [r/paracosms/](https://www.reddit.com/r/paracosms/)
   
   > If you want to view paradise
   > Simply look around and view it
   > Anything you want to, do it
   > Want to change the world?
   > There's nothing to it
-  - Pure Imagination: https://youtu.be/SVi3-PrQ0pY
+  - Pure Imagination: [Gene Wilder - Pure Imagination](https://www.youtube.com/watch?v=SVi3-PrQ0pY)
+
   
   Background:
     Given you have a mental world in mind

--- a/bonus/quantum-pause.feature
+++ b/bonus/quantum-pause.feature
@@ -5,7 +5,7 @@ Feature: The Quantum Pause
   of contact with your inmost self, allowing you to work through situations by 
   their wisdom, and reinforcing their presence in the life of the individual.
   
-  A longer introduction to this process is here: http://wespenre.com/pdf/Appendix-cognitive-section-quantum-pause-breathing-exercise.pdf
+  A longer introduction to this process is here: [The Quantum Pause Breathing Exercise](https://web.archive.org/web/20121224082813/http://wespenre.com/pdf/Appendix-cognitive-section-quantum-pause-breathing-exercise.pdf)
   
   At a high level this is metta mixed with box breathing mixed with mindfulness.
   

--- a/bonus/void.feature
+++ b/bonus/void.feature
@@ -19,7 +19,7 @@ Feature: Void Meditation
   falling asleep during meditation.
 
   This method is based on a method handed around occult practice IRC channels
-  and is adapted from this pastebin link: https://pastebin.com/7JCfUJKZ
+  and is adapted from this pastebin link: [Void Meditation - Pastebin](https://pastebin.com/7JCfUJKZ)
   Please note that the pastebin link is written in more of an occult/magickal
   lens and as such will use in-lens terminology.
 

--- a/intro.md
+++ b/intro.md
@@ -83,7 +83,7 @@ feature:
 
 > Note: "the body" means the sack of meat and bone that you are currently living inside. For the purposes of explanation of this technique, please consider what makes you yourself separate from the body you live in.
 
-You are not your thoughts. Your thoughts are something [you can witness](https://github.com/Xe/when-then-zen/blob/master/bonus/noting.feature).
+You are not your thoughts. Your thoughts are something [you can witness](/bonus/noting.feature).
 You are not required to give your thoughts any attention they don't need. Try
 not immediately associating yourself with a few "negative" thoughts when they 
 come up next. Try digging through the chains of meaning to understand why they
@@ -105,7 +105,7 @@ sub-par teachers. A lot of it got so ingrained in the culture that the actions
 themselves can be confused with the culture.
 
 I do not plan to set too many expectations for what people will experience.
-When possible, [I tell people to avoid having "spiritual experiences"](https://github.com/Xe/when-then-zen/blob/master/bonus/quantum-pause.feature#L12-L16).
+When possible, [I tell people to avoid having "spiritual experiences"](/quantum-pause.feature#L12-L16).
 
 ## Other Topics I Want to Cover
 


### PR DESCRIPTION
Did a little audit of links, finding that some were:
* dead -> got archive.org references
* non-clickable -> created markdown versions 
   * needs testing for proper formatting to see if modifications were correct...
* absolute -> relative
   * these links lead the reader to the actual github blobs, instead of staying in the pretty website view. Links need testing to make sure mods were correct...


Note: changes made to `/bonus/*` need to be replicated to identical (?) content at `/meditation/*` - two sources of truth?

Hope this is helpful... none of the changes were tested, but they were carefully considered.

Thanks for the great read otherwise!